### PR TITLE
Calculate size that doesn't consider parent rotation

### DIFF
--- a/.storybook/stories/Rotation.stories.tsx
+++ b/.storybook/stories/Rotation.stories.tsx
@@ -1,0 +1,84 @@
+import { Box, Flex } from '../../src'
+import React, { Suspense } from 'react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+
+import { Setup } from '../Setup'
+import { MathUtils } from 'three'
+
+const { degToRad } = MathUtils
+
+const Rotation = ({
+  rotationX,
+  rotationY,
+  rotationZ,
+  rotationXItems,
+  rotationYItems,
+  rotationZItems,
+}: {
+  rotationX: number
+  rotationY: number
+  rotationZ: number
+  rotationXItems: number
+  rotationYItems: number
+  rotationZItems: number
+}) => {
+  const width = 3
+  const height = 1
+  return (
+    <Flex
+      size={[width, height, 0]}
+      flexDirection="row"
+      flexWrap="no-wrap"
+      alignItems="stretch"
+      justifyContent="flex-start"
+      position={[0, 0, 3]}
+      rotation={[degToRad(rotationX), degToRad(rotationY), degToRad(rotationZ)]}
+    >
+      <Box rotation={[degToRad(rotationXItems), degToRad(rotationYItems), degToRad(rotationZItems)]} centerAnchor>
+        <mesh scale={1}>
+          <boxGeometry args={[1, 1, 1]} />
+          <meshBasicMaterial color="red" wireframe />
+        </mesh>
+      </Box>
+      <Box rotation={[degToRad(rotationXItems), degToRad(rotationYItems), degToRad(rotationZItems)]} centerAnchor>
+        <mesh>
+          <boxGeometry args={[1, 1, 1]} />
+          <meshBasicMaterial color="orange" wireframe />
+        </mesh>
+      </Box>
+    </Flex>
+  )
+}
+
+export default {
+  title: 'Example/Rotation',
+  component: Rotation,
+} as ComponentMeta<typeof Rotation>
+
+const Template: ComponentStory<typeof Rotation> = (args) => (
+  <Setup lights={false}>
+    <Suspense fallback={null}>
+      <Rotation {...args} />
+    </Suspense>
+  </Setup>
+)
+
+export const RootRotated = Template.bind({})
+RootRotated.args = {
+  rotationX: 10,
+  rotationY: 30,
+  rotationZ: 10,
+  rotationXItems: 0,
+  rotationYItems: 0,
+  rotationZItems: 0,
+}
+
+export const ItemsRotated = Template.bind({})
+ItemsRotated.args = {
+  rotationX: 0,
+  rotationY: 0,
+  rotationZ: 0,
+  rotationXItems: 0,
+  rotationYItems: 45,
+  rotationZItems: 0,
+}

--- a/src/Flex.tsx
+++ b/src/Flex.tsx
@@ -3,7 +3,15 @@ import Yoga, { YogaNode } from 'yoga-layout-prebuilt'
 import { Vector3, Group, Box3, Object3D } from 'three'
 import { useFrame, useThree, ReactThreeFiber } from '@react-three/fiber'
 
-import { setYogaProperties, rmUndefFromObj, vectorFromObject, Axis, getDepthAxis, getFlex2DSize } from './util'
+import {
+  setYogaProperties,
+  rmUndefFromObj,
+  vectorFromObject,
+  Axis,
+  getDepthAxis,
+  getFlex2DSize,
+  getOBBSize,
+} from './util'
 import { boxContext, flexContext, SharedFlexContext, SharedBoxContext } from './context'
 import type { R3FlexProps, FlexYogaDirection, FlexPlane } from './props'
 
@@ -209,6 +217,8 @@ export function Flex({
     wrap,
   ])
 
+  const rootGroup = useRef<Group>()
+
   // Keeps track of the yoga nodes of the children and the related wrapper groups
   const boxesRef = useRef<BoxesItem[]>([])
   const registerBox = useCallback(
@@ -285,8 +295,14 @@ export function Flex({
           node.setWidth(scaledWidth)
           node.setHeight(scaledHeight)
         } else if (!hasBoxChildren(boxesRef.current, group.children)) {
-          // No size specified, calculate bounding box
-          boundingBox.setFromObject(group).getSize(vec)
+          // No size specified, calculate size
+          if (rootGroup.current) {
+            getOBBSize(group, rootGroup.current, boundingBox, vec)
+          } else {
+            // rootGroup ref is missing for some reason, let's just use usual bounding box
+            boundingBox.setFromObject(group).getSize(vec)
+          }
+
           node.setWidth(scaledWidth || vec[mainAxis] * scaleFactor)
           node.setHeight(scaledHeight || vec[crossAxis] * scaleFactor)
         }
@@ -333,7 +349,7 @@ export function Flex({
   })
 
   return (
-    <group {...props}>
+    <group ref={rootGroup} {...props}>
       <flexContext.Provider value={sharedFlexContext}>
         <boxContext.Provider value={sharedBoxContext}>{children}</boxContext.Provider>
       </flexContext.Provider>


### PR DESCRIPTION
Adapted code from https://github.com/mrdoob/three.js/issues/11967
Calculates oriented bounding box size
Essentially it negates flex root rotation to provide proper number
E.g. if root flex group rotatet 45 degress, a cube box of size 1 will
report sizes of sqrt(2), but it should still be 1

NB: This doesn't work when object itself is rotated (well, for now)